### PR TITLE
Add Setting and SettingGroup components

### DIFF
--- a/.changeset/jolly-crabs-try.md
+++ b/.changeset/jolly-crabs-try.md
@@ -1,0 +1,5 @@
+---
+'obsidian-svelte-ui': minor
+---
+
+add default generic type for `SvelteComponent`

--- a/.changeset/red-garlics-knock.md
+++ b/.changeset/red-garlics-knock.md
@@ -1,0 +1,5 @@
+---
+'obsidian-svelte-ui': minor
+---
+
+Add `Setting` and `SettingGroup` components

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ within this package to be correctly resolved.
 | [`ProgressBar`](obsidian-svelte-ui/docs/components/ProgressBar.md)   | Wraps Obsidian's `ProgressBarComponent`  |
 | [`Search`](obsidian-svelte-ui/docs/components/Search.md)             | Wraps Obsidian's `SearchComponent`       |
 | [`Secret`](obsidian-svelte-ui/docs/components/Secret.md)             | Wraps Obsidian's `SecretComponent`       |
+| [`Setting`](obsidian-svelte-ui/docs/components/Setting.md)           | Wraps Obsidian's `Setting`               |
+| [`SettingGroup`](obsidian-svelte-ui/docs/components/SettingGroup.md) | Wraps Obsidian's `SettingGroup`          |
 | [`Slider`](obsidian-svelte-ui/docs/components/Slider.md)             | Wraps Obsidian's `SliderComponent`       |
 | [`Text`](obsidian-svelte-ui/docs/components/Text.md)                 | Wraps Obsidian's `TextComponent`         |
 | [`TextArea`](obsidian-svelte-ui/docs/components/TextArea.md)         | Wraps Obsidian's `TextAreaComponent`     |

--- a/demo-plugin/README.md
+++ b/demo-plugin/README.md
@@ -16,6 +16,10 @@ To browse this within `demo-vault`, run the command `"Demo Obsidian Svelte UI: O
 
 [`view.ts`](./src/view.ts) demonstrates populating an Obsidian view by mounting a Svelte component.
 
+### Example Settings Implementation
+
+[`settings.ts`](./src/settings.ts) demonstrates populating an Obsidian Settings panel by mounting a Svelte component.
+
 ## Running this Locally
 
 1. Clone this repo

--- a/demo-plugin/src/Settings.svelte
+++ b/demo-plugin/src/Settings.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { Text, Search, ExtraButton, Setting, SettingGroup } from 'obsidian-svelte-ui';
+
+	import type DemoObsidianSvelteUI from './main';
+
+	interface Props {
+		plugin: DemoObsidianSvelteUI;
+	}
+
+	let { plugin }: Props = $props();
+
+	async function save(value: string) {
+		plugin.settings.mySetting = value;
+		await plugin.saveSettings();
+	}
+</script>
+
+<SettingGroup heading="First Group">
+	{#snippet controls()}
+		<ExtraButton icon="lucide-search" />
+	{/snippet}
+
+	{#snippet search()}
+		<Search placeholder="Search Input" />
+	{/snippet}
+
+	{#snippet children()}
+		<Setting name="Settings #1" desc="It's a secret">
+			<Text
+				placeholder="Enter your secret"
+				value={plugin.settings.mySetting}
+				onChange={save}
+			/>
+		</Setting>
+	{/snippet}
+</SettingGroup>
+
+<SettingGroup heading="Second Group">
+	{#snippet controls()}
+		<ExtraButton icon="lucide-search" />
+	{/snippet}
+
+	{#snippet search()}
+		<Search placeholder="Search Input" />
+	{/snippet}
+
+	{#snippet children()}
+		<Setting name="Settings #1" desc="It's a secret">
+			<Text
+				placeholder="Enter your secret"
+				value={plugin.settings.mySetting}
+				onChange={save}
+			/>
+		</Setting>
+	{/snippet}
+</SettingGroup>

--- a/demo-plugin/src/settings.ts
+++ b/demo-plugin/src/settings.ts
@@ -1,5 +1,8 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
-import DemoObsidianSvelteUI from './main';
+import { App, PluginSettingTab } from 'obsidian';
+import { SvelteComponent } from 'obsidian-svelte-ui';
+
+import type DemoObsidianSvelteUI from './main';
+import Settings from './Settings.svelte';
 
 export interface DemoSettings {
 	mySetting: string;
@@ -12,27 +15,25 @@ export const DEFAULT_SETTINGS: DemoSettings = {
 export class ObsidianSvelteuiSettingsTab extends PluginSettingTab {
 	plugin: DemoObsidianSvelteUI;
 
+	private view?: SvelteComponent;
+
 	constructor(app: App, plugin: DemoObsidianSvelteUI) {
 		super(app, plugin);
 		this.plugin = plugin;
 	}
 
 	display(): void {
-		const { containerEl } = this;
+		this.view = new SvelteComponent(Settings, {
+			target: this.containerEl,
+			props: {
+				plugin: this.plugin
+			}
+		});
+		this.view.load();
+	}
 
-		containerEl.empty();
-
-		new Setting(containerEl)
-			.setName('Settings #1')
-			.setDesc("It's a secret")
-			.addText((text) =>
-				text
-					.setPlaceholder('Enter your secret')
-					.setValue(this.plugin.settings.mySetting)
-					.onChange(async (value) => {
-						this.plugin.settings.mySetting = value;
-						await this.plugin.saveSettings();
-					})
-			);
+	hide(): void {
+		this.view?.unload();
+		this.view = undefined;
 	}
 }

--- a/obsidian-svelte-ui/docs/components/Setting.md
+++ b/obsidian-svelte-ui/docs/components/Setting.md
@@ -1,0 +1,36 @@
+# `Setting`
+
+Wraps Obsidian's `Setting` class as a Svelte component. Renders a labelled row with a name, description, and optional control area.
+
+```svelte
+<script>
+	import { Setting, Toggle } from 'obsidian-svelte-ui';
+
+	let enabled = $state(false);
+</script>
+
+<Setting name="Enable feature" desc="Does the thing">
+	<Toggle value={enabled} onChange={(v) => (enabled = v)} />
+</Setting>
+```
+
+Use the `heading` prop to render the row as a section heading instead of a form control:
+
+```svelte
+<Setting heading name="Advanced" />
+```
+
+## Props
+
+| Prop             | Type             | Default | Description                                              |
+| ---------------- | ---------------- | ------- | -------------------------------------------------------- |
+| `children`       | `Snippet`        | —       | Controls rendered into the right-hand `controlEl` area   |
+| `class`          | `string`         | —       | Additional CSS class applied to the setting row          |
+| `desc`           | `string`         | —       | Description text shown below the name                    |
+| `disabled`       | `boolean`        | `false` | Disables the setting row                                 |
+| `heading`        | `boolean`        | `false` | Renders the row as a section heading (no control layout) |
+| `name`           | `string`         | —       | Label text for the setting                               |
+| `tooltip`        | `string`         | —       | Tooltip shown on hover                                   |
+| `tooltipOptions` | `TooltipOptions` | —       | Options passed to `setTooltip`                           |
+
+The `children` snippet is rendered into Obsidian's `controlEl`, allowing any of the existing form components (`Toggle`, `Button`, `Text`, etc.) to be placed there directly.

--- a/obsidian-svelte-ui/docs/components/SettingGroup.md
+++ b/obsidian-svelte-ui/docs/components/SettingGroup.md
@@ -1,0 +1,27 @@
+# `SettingGroup`
+
+Wraps Obsidian's `SettingGroup` class as a Svelte component. Groups multiple settings under a shared heading.
+
+```svelte
+<script>
+	import { Setting, SettingGroup, Toggle } from 'obsidian-svelte-ui';
+
+	let enabled = $state(false);
+</script>
+
+<SettingGroup heading="Advanced">
+	<Setting name="Enable feature" desc="Does the thing">
+		<Toggle value={enabled} onChange={(v) => (enabled = v)} />
+	</Setting>
+</SettingGroup>
+```
+
+`<Search>` and `<ExtraButton>` children can also be placed inside the group, matching the `addSearch` and `addExtraButton` methods on the Obsidian API.
+
+## Props
+
+| Prop       | Type      | Default | Description                                                              |
+| ---------- | --------- | ------- | ------------------------------------------------------------------------ |
+| `children` | `Snippet` | —       | `Setting`, `Search`, or `ExtraButton` components rendered into the group |
+| `class`    | `string`  | —       | CSS class added to the group element                                     |
+| `heading`  | `string`  | —       | Heading text displayed above the group                                   |

--- a/obsidian-svelte-ui/docs/components/SettingGroup.md
+++ b/obsidian-svelte-ui/docs/components/SettingGroup.md
@@ -4,24 +4,34 @@ Wraps Obsidian's `SettingGroup` class as a Svelte component. Groups multiple set
 
 ```svelte
 <script>
-	import { Setting, SettingGroup, Toggle } from 'obsidian-svelte-ui';
-
-	let enabled = $state(false);
+	import { ExtraButton, Search, Setting, SettingGroup, Text } from 'obsidian-svelte-ui';
 </script>
 
 <SettingGroup heading="Advanced">
-	<Setting name="Enable feature" desc="Does the thing">
-		<Toggle value={enabled} onChange={(v) => (enabled = v)} />
-	</Setting>
+	{#snippet controls()}
+		<ExtraButton icon="lucide-refresh-cw" />
+	{/snippet}
+
+	{#snippet search()}
+		<Search placeholder="Filter settings..." />
+	{/snippet}
+
+	{#snippet children()}
+		<Setting name="Enable feature" desc="Does the thing">
+			<Text value="example" />
+		</Setting>
+	{/snippet}
 </SettingGroup>
 ```
 
-`<Search>` and `<ExtraButton>` children can also be placed inside the group, matching the `addSearch` and `addExtraButton` methods on the Obsidian API.
+The `controls`, `search`, and `children` snippets correspond to the `addExtraButton`, `addSearch`, and `addSetting` methods on the Obsidian `SettingGroup` API respectively.
 
 ## Props
 
-| Prop       | Type      | Default | Description                                                              |
-| ---------- | --------- | ------- | ------------------------------------------------------------------------ |
-| `children` | `Snippet` | —       | `Setting`, `Search`, or `ExtraButton` components rendered into the group |
-| `class`    | `string`  | —       | CSS class added to the group element                                     |
-| `heading`  | `string`  | —       | Heading text displayed above the group                                   |
+| Prop       | Type      | Default | Description                                              |
+| ---------- | --------- | ------- | -------------------------------------------------------- |
+| `children` | `Snippet` | —       | `Setting` components rendered into the group body        |
+| `class`    | `string`  | —       | CSS class added to the group element                     |
+| `controls` | `Snippet` | —       | `ExtraButton` components rendered into the group heading |
+| `heading`  | `string`  | —       | Heading text displayed above the group                   |
+| `search`   | `Snippet` | —       | `Search` component rendered into the group heading       |

--- a/obsidian-svelte-ui/src/lib/components/Setting.svelte
+++ b/obsidian-svelte-ui/src/lib/components/Setting.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { Setting as ObsidianSetting, type TooltipOptions } from 'obsidian';
-	import { ImperativeComponent } from 'svelte-imperative';
 
 	import BindAttachments from '$lib/utils/BindAttachments.svelte';
 	import ExposeContainerElement from '$lib/utils/ExposeContainerElement.svelte';
-	import RenderSnippet from '$lib/utils/RenderSnippet.svelte';
+	import { bindSnippet } from '$lib/utils/RenderSnippet.svelte';
 	import {
 		bindMethodArgumentsToProps,
 		bindMethodsToBooleanProps,
@@ -65,11 +64,10 @@
 		}
 	);
 
-	$effect(() => {
-		if (!controlEl || !children) return;
-		const ic = new ImperativeComponent(controlEl, RenderSnippet, { snippet: children });
-		return () => ic.destroy();
-	});
+	bindSnippet(
+		() => controlEl,
+		() => children
+	);
 </script>
 
 <ExposeContainerElement bind:containerEl />

--- a/obsidian-svelte-ui/src/lib/components/Setting.svelte
+++ b/obsidian-svelte-ui/src/lib/components/Setting.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { Setting as ObsidianSetting, type TooltipOptions } from 'obsidian';
+	import { ImperativeComponent } from 'svelte-imperative';
+
+	import BindAttachments from '$lib/utils/BindAttachments.svelte';
+	import ExposeContainerElement from '$lib/utils/ExposeContainerElement.svelte';
+	import RenderSnippet from '$lib/utils/RenderSnippet.svelte';
+	import {
+		bindMethodArgumentsToProps,
+		bindMethodsToBooleanProps,
+		bindPropToMethod
+	} from '$lib/utils/props-to-methods.svelte';
+
+	interface Props {
+		children?: Snippet;
+		class?: string;
+		desc?: string;
+		disabled?: boolean;
+		heading?: boolean;
+		name?: string;
+		tooltip?: string;
+		tooltipOptions?: TooltipOptions;
+	}
+
+	let {
+		children,
+		class: cls,
+		desc,
+		disabled = false,
+		heading = false,
+		name,
+		tooltip,
+		tooltipOptions,
+		...rest
+	}: Props = $props();
+
+	let containerEl: HTMLElement | null | undefined = $state();
+
+	let instance = $derived.by(() => {
+		if (containerEl) {
+			return new ObsidianSetting(containerEl);
+		}
+	});
+
+	let controlEl = $derived(instance?.controlEl);
+	let settingEl = $derived(instance?.settingEl);
+
+	bindMethodArgumentsToProps(() => instance, {
+		setClass: () => cls,
+		setDesc: () => desc,
+		setDisabled: () => disabled,
+		setName: () => name
+	});
+
+	bindMethodsToBooleanProps(() => instance, {
+		setHeading: () => heading
+	});
+
+	bindPropToMethod(
+		() => instance,
+		() => tooltip,
+		(c, v) => {
+			if (v !== undefined) c.setTooltip(v, tooltipOptions);
+		}
+	);
+
+	$effect(() => {
+		if (!controlEl || !children) return;
+		const ic = new ImperativeComponent(controlEl, RenderSnippet, { snippet: children });
+		return () => ic.destroy();
+	});
+</script>
+
+<ExposeContainerElement bind:containerEl />
+<BindAttachments node={settingEl} {...rest} />

--- a/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
+++ b/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { SettingGroup as ObsidianSettingGroup } from 'obsidian';
+	import { ImperativeComponent } from 'svelte-imperative';
+
+	import ExposeContainerElement from '$lib/utils/ExposeContainerElement.svelte';
+	import RenderSnippet from '$lib/utils/RenderSnippet.svelte';
+	import { bindMethodArgumentsToProps } from '$lib/utils/props-to-methods.svelte';
+
+	interface Props {
+		children?: Snippet;
+		class?: string;
+		heading?: string;
+	}
+
+	let { children, class: cls, heading }: Props = $props();
+
+	let containerEl: HTMLElement | null | undefined = $state();
+
+	let instance = $derived.by(() => {
+		if (containerEl) {
+			return new ObsidianSettingGroup(containerEl);
+		}
+	});
+
+	// Probe the group's inner container via addSetting, then remove the empty row.
+	let innerContainerEl: HTMLElement | null | undefined = $state();
+
+	$effect(() => {
+		if (!instance) {
+			innerContainerEl = undefined;
+			return;
+		}
+		instance.addSetting((s) => {
+			innerContainerEl = s.settingEl.parentElement;
+			s.settingEl.remove();
+		});
+	});
+
+	bindMethodArgumentsToProps(() => instance, {
+		addClass: () => cls,
+		setHeading: () => heading
+	});
+
+	$effect(() => {
+		if (!innerContainerEl || !children) return;
+		const ic = new ImperativeComponent(innerContainerEl, RenderSnippet, { snippet: children });
+		return () => ic.destroy();
+	});
+</script>
+
+<ExposeContainerElement bind:containerEl />

--- a/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
+++ b/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
@@ -1,19 +1,29 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { SettingGroup as ObsidianSettingGroup } from 'obsidian';
+	import { SettingGroup as ObsidianSettingGroup, type SearchComponent } from 'obsidian';
 	import { ImperativeComponent } from 'svelte-imperative';
 
 	import ExposeContainerElement from '$lib/utils/ExposeContainerElement.svelte';
 	import RenderSnippet from '$lib/utils/RenderSnippet.svelte';
 	import { bindMethodArgumentsToProps } from '$lib/utils/props-to-methods.svelte';
 
+	interface SearchComponentWithDOMRef extends SearchComponent {
+		containerEl: HTMLElement;
+	}
+
+	function hasDOMRef(search: SearchComponent): search is SearchComponentWithDOMRef {
+		return 'containerEl' in search;
+	}
+
 	interface Props {
 		children?: Snippet;
 		class?: string;
+		controls?: Snippet;
 		heading?: string;
+		search?: Snippet;
 	}
 
-	let { children, class: cls, heading }: Props = $props();
+	let { children, class: cls, controls, heading, search }: Props = $props();
 
 	let containerEl: HTMLElement | null | undefined = $state();
 
@@ -23,29 +33,65 @@
 		}
 	});
 
-	// Probe the group's inner container via addSetting, then remove the empty row.
-	let innerContainerEl: HTMLElement | null | undefined = $state();
+	$effect(() => {
+		let settingItemsContainerEl: HTMLElement | null | undefined;
+
+		if (instance && children) {
+			instance.addSetting((s) => {
+				settingItemsContainerEl = s.settingEl.parentElement;
+				s.settingEl.remove();
+			});
+		}
+
+		if (settingItemsContainerEl) {
+			const ic = new ImperativeComponent(settingItemsContainerEl, RenderSnippet, {
+				snippet: children
+			});
+			return () => ic.destroy();
+		}
+	});
 
 	$effect(() => {
-		if (!instance) {
-			innerContainerEl = undefined;
-			return;
+		let controlContainerEl: HTMLElement | null | undefined;
+
+		if (instance && controls) {
+			instance.addExtraButton((b) => {
+				controlContainerEl = b.extraSettingsEl.parentElement;
+				b.extraSettingsEl.remove();
+			});
 		}
-		instance.addSetting((s) => {
-			innerContainerEl = s.settingEl.parentElement;
-			s.settingEl.remove();
-		});
+
+		if (controlContainerEl) {
+			const ic = new ImperativeComponent(controlContainerEl, RenderSnippet, {
+				snippet: controls
+			});
+			return () => ic.destroy();
+		}
+	});
+
+	$effect(() => {
+		let searchContainerEl: HTMLElement | null | undefined;
+
+		if (instance && search) {
+			instance.addSearch((s) => {
+				if (hasDOMRef(s)) {
+					searchContainerEl = s.containerEl.parentElement;
+					s.containerEl.remove();
+				}
+			});
+		}
+
+		if (searchContainerEl) {
+			const ic = new ImperativeComponent(searchContainerEl, RenderSnippet, {
+				snippet: search
+			});
+			return () => ic.destroy();
+		}
 	});
 
 	bindMethodArgumentsToProps(() => instance, {
 		addClass: () => cls,
 		setHeading: () => heading
-	});
-
-	$effect(() => {
-		if (!innerContainerEl || !children) return;
-		const ic = new ImperativeComponent(innerContainerEl, RenderSnippet, { snippet: children });
-		return () => ic.destroy();
 	});
 </script>
 

--- a/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
+++ b/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
@@ -96,3 +96,12 @@
 </script>
 
 <ExposeContainerElement bind:containerEl />
+
+<style>
+	/* Emulate setting group spacing, accounting for mount point elements */
+	:global(.obsidian-svelte-ui-mount-point:has(.setting-group))
+		+ :global(.obsidian-svelte-ui-mount-point)
+		:global(.setting-group) {
+		margin-top: var(--size-4-6);
+	}
+</style>

--- a/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
+++ b/obsidian-svelte-ui/src/lib/components/SettingGroup.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { SettingGroup as ObsidianSettingGroup, type SearchComponent } from 'obsidian';
-	import { ImperativeComponent } from 'svelte-imperative';
 
 	import ExposeContainerElement from '$lib/utils/ExposeContainerElement.svelte';
-	import RenderSnippet from '$lib/utils/RenderSnippet.svelte';
+	import { bindSnippet } from '$lib/utils/RenderSnippet.svelte';
 	import { bindMethodArgumentsToProps } from '$lib/utils/props-to-methods.svelte';
 
 	interface SearchComponentWithDOMRef extends SearchComponent {
@@ -33,61 +32,55 @@
 		}
 	});
 
-	$effect(() => {
-		let settingItemsContainerEl: HTMLElement | null | undefined;
+	let settingItemsContainerEl = $state<HTMLElement>();
 
+	$effect(() => {
 		if (instance && children) {
-			instance.addSetting((s) => {
-				settingItemsContainerEl = s.settingEl.parentElement;
+			instance?.addSetting((s) => {
+				settingItemsContainerEl = s.settingEl.parentElement ?? undefined;
 				s.settingEl.remove();
 			});
 		}
-
-		if (settingItemsContainerEl) {
-			const ic = new ImperativeComponent(settingItemsContainerEl, RenderSnippet, {
-				snippet: children
-			});
-			return () => ic.destroy();
-		}
 	});
 
-	$effect(() => {
-		let controlContainerEl: HTMLElement | null | undefined;
+	bindSnippet(
+		() => settingItemsContainerEl,
+		() => children
+	);
 
+	let controlContainerEl = $state<HTMLElement>();
+
+	$effect(() => {
 		if (instance && controls) {
 			instance.addExtraButton((b) => {
-				controlContainerEl = b.extraSettingsEl.parentElement;
+				controlContainerEl = b.extraSettingsEl.parentElement ?? undefined;
 				b.extraSettingsEl.remove();
 			});
 		}
-
-		if (controlContainerEl) {
-			const ic = new ImperativeComponent(controlContainerEl, RenderSnippet, {
-				snippet: controls
-			});
-			return () => ic.destroy();
-		}
 	});
 
-	$effect(() => {
-		let searchContainerEl: HTMLElement | null | undefined;
+	bindSnippet(
+		() => controlContainerEl,
+		() => controls
+	);
 
+	let searchContainerEl = $state<HTMLElement>();
+
+	$effect(() => {
 		if (instance && search) {
 			instance.addSearch((s) => {
 				if (hasDOMRef(s)) {
-					searchContainerEl = s.containerEl.parentElement;
+					searchContainerEl = s.containerEl.parentElement ?? undefined;
 					s.containerEl.remove();
 				}
 			});
 		}
-
-		if (searchContainerEl) {
-			const ic = new ImperativeComponent(searchContainerEl, RenderSnippet, {
-				snippet: search
-			});
-			return () => ic.destroy();
-		}
 	});
+
+	bindSnippet(
+		() => searchContainerEl,
+		() => search
+	);
 
 	bindMethodArgumentsToProps(() => instance, {
 		addClass: () => cls,

--- a/obsidian-svelte-ui/src/lib/index.ts
+++ b/obsidian-svelte-ui/src/lib/index.ts
@@ -7,6 +7,8 @@ export { default as MomentFormat } from './components/MomentFormat.svelte';
 export { default as ProgressBar } from './components/ProgressBar.svelte';
 export { default as Search } from './components/Search.svelte';
 export { default as Secret } from './components/Secret.svelte';
+export { default as Setting } from './components/Setting.svelte';
+export { default as SettingGroup } from './components/SettingGroup.svelte';
 export { default as Slider } from './components/Slider.svelte';
 export { default as Text } from './components/Text.svelte';
 export { default as TextArea } from './components/TextArea.svelte';

--- a/obsidian-svelte-ui/src/lib/svelte-component.ts
+++ b/obsidian-svelte-ui/src/lib/svelte-component.ts
@@ -7,7 +7,9 @@ interface Options<Props> {
 	target: HTMLElement;
 }
 
-export class SvelteComponent<Props extends Record<string, any>> extends ObsidianComponent {
+export class SvelteComponent<
+	Props extends Record<string, any> = Record<string, any>
+> extends ObsidianComponent {
 	private component: Component<Props>;
 	private options: Options<Props>;
 

--- a/obsidian-svelte-ui/src/lib/utils/ExposeContainerElement.svelte
+++ b/obsidian-svelte-ui/src/lib/utils/ExposeContainerElement.svelte
@@ -6,4 +6,10 @@
 	let { containerEl = $bindable() }: Props = $props();
 </script>
 
-<div style="display: contents;" bind:this={containerEl}></div>
+<div class="obsidian-svelte-ui-mount-point" bind:this={containerEl}></div>
+
+<style>
+	.obsidian-svelte-ui-mount-point {
+		display: contents;
+	}
+</style>

--- a/obsidian-svelte-ui/src/lib/utils/RenderSnippet.svelte
+++ b/obsidian-svelte-ui/src/lib/utils/RenderSnippet.svelte
@@ -1,3 +1,22 @@
+<script lang="ts" module>
+	import { ImperativeComponent } from 'svelte-imperative';
+	import RenderSnippet from './RenderSnippet.svelte';
+
+	export function bindSnippet(
+		produceRoot: () => HTMLElement | undefined,
+		produceSnippet: () => Snippet | undefined
+	) {
+		$effect(() => {
+			const root = produceRoot();
+			const snippet = produceSnippet();
+
+			if (!root || !snippet) return;
+			const ic = new ImperativeComponent(root, RenderSnippet, { snippet });
+			return () => ic.destroy();
+		});
+	}
+</script>
+
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Resolves #5 — adds Svelte wrappers for Obsidian's `Setting` and `SettingGroup` classes.

- **`Setting`**: renders a labelled row with `name`, `desc`, `class`, `disabled`, `heading` (boolean), and `tooltip` props. A `children` snippet is rendered into Obsidian's `controlEl` via `ImperativeComponent`, allowing any existing form components (`Toggle`, `Button`, `Text`, etc.) to be used directly as controls.
- **`SettingGroup`**: groups multiple settings under a `heading`. Children (`Setting`, `Search`, `ExtraButton`) are rendered into the group's inner container, discovered at runtime via a one-shot `addSetting` probe.

Both components follow the same patterns as existing wrappers (`bindMethodArgumentsToProps`, `bindMethodsToBooleanProps`, `ExposeContainerElement`), and include documentation in `docs/components/`.

## Usage

```svelte
<script>
  import { Setting, SettingGroup, Toggle } from 'obsidian-svelte-ui';
  let enabled = $state(false);
</script>

<SettingGroup heading="Advanced">
  <Setting name="Enable feature" desc="Does the thing">
    <Toggle value={enabled} onChange={(v) => (enabled = v)} />
  </Setting>
  <Setting heading name="Danger zone" />
</SettingGroup>
```

## Test plan

- [ ] `Setting` renders a setting row with name/desc text
- [ ] `Setting` children (e.g. `Toggle`) appear in the control area on the right
- [ ] `Setting heading` renders a heading row with no control layout
- [ ] `Setting disabled` grays out the row
- [ ] `SettingGroup heading="..."` renders a group with the correct heading
- [ ] `Setting` children inside `SettingGroup` appear inside the group's container
- [ ] `Search` and `ExtraButton` children inside `SettingGroup` render correctly

https://claude.ai/code/session_01Kj6HEjHpUW1jnQn5x1Zo11
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj6HEjHpUW1jnQn5x1Zo11)_